### PR TITLE
Fixing ISS-356

### DIFF
--- a/Sources/cURL.swift
+++ b/Sources/cURL.swift
@@ -113,15 +113,7 @@ public class CURL {
 		}
 		let _ = setOption(CURLOPT_WRITEFUNCTION, f: writeFunc)
 
-		let readFunc: curl_func = {
-			(a, b, c, p) -> Int in
-
-			// !FIX!
-
-//			let crl = Unmanaged<CURL>.fromOpaque(COpaquePointer(p)).takeUnretainedValue()
-			return 0
-		}
-		_ = setOption(CURLOPT_READFUNCTION, f: readFunc)
+		let _ = setOption(CURLOPT_READFUNCTION, f: { fread($0, $1, $2, unsafeBitCast($3, to: UnsafeMutablePointer<FILE>.self)) })
 
 	}
 
@@ -335,7 +327,7 @@ public class CURL {
 			CURLOPT_POSTQUOTE.rawValue,
 			CURLOPT_PREQUOTE.rawValue,
 			CURLOPT_QUOTE.rawValue,
-			CURLOPT_MAIL_FROM.rawValue,
+			//CURLOPT_MAIL_FROM.rawValue,
 			CURLOPT_MAIL_RCPT.rawValue:
             let slists = curl_slist_append(self.slists, s)
 			guard slists != nil else {


### PR DESCRIPTION
1. Fixing internal `fread()` for CURLOPT_READFUNCTION by referring to
https://curl.haxx.se/libcurl/c/CURLOPT_READDATA.html
2. Fixing ISS-356 “CURLOPT_MAIL_FROM and CURLOPT_MAIL_RCPT are mixed
and failed”
3. Adding an SMTP example for testing the above patches.