### PR TITLE
Adding formAddPost

### DIFF
--- a/Sources/cURL.swift
+++ b/Sources/cURL.swift
@@ -423,5 +423,59 @@ public class CURL {
 		}
 		return curl_easy_setopt_cstr(self.curl!, option, s)
 	}
-}
 
+  public class POSTFields {
+    internal var first = UnsafeMutablePointer<curl_httppost>(bitPattern: 0)
+    internal var last = UnsafeMutablePointer<curl_httppost>(bitPattern: 0)
+
+    /// constructor, create a blank form without any fields
+    /// must append each field manually
+    public init() { }
+
+    /// add a post field
+    /// - parameters:
+    ///   - key: post field name
+    ///   - value: post field value string
+    ///   - type: post field type, e.g., "text/html".
+    ///  - returns:
+    ///   CURLFORMCode, 0 for ok
+    public func append(key: String, value: String, mimeType: String = "") -> CURLFORMcode {
+      return curl_formadd_content(&first, &last, key, value, 0, mimeType.isEmpty ? nil : mimeType)
+    }//end append
+
+    /// add a post field
+    /// - parameters:
+    ///   - key: post field name
+    ///   - buffer: post field value, binary buffer
+    ///   - type: post field type, e.g., "image/jpeg".
+    ///  - throws:
+    ///   CURLFORMCode, 0 for ok
+    public func append(key: String, buffer: [Int8], mimeType: String = "") -> CURLFORMcode {
+      return curl_formadd_content(&first, &last, key, buffer, buffer.count, mimeType.isEmpty ? nil : mimeType)
+    }//end append
+
+    /// add a post field
+    /// - parameters:
+    ///   - key: post field name
+    ///   - value: post field value string
+    ///   - type: post field mime type, e.g., "image/jpeg".
+    ///  - throws:
+    ///   CURLFORMCode, 0 for ok
+    public func append(key: String, path: String, mimeType: String = "") -> CURLFORMcode {
+      return curl_formadd_file(&first, &last, key, path, mimeType.isEmpty ? nil : mimeType)
+    }//end append
+
+    deinit {
+      curl_formfree(first)
+      //curl_formfree(last)
+    }//end deinit
+  }//end class
+
+  /// Post a form with different fields.
+  public func formAddPost(fields: POSTFields) ->CURLcode {
+    guard let p = fields.first else {
+      return CURLcode(rawValue: 4096)
+    }//end guard
+    return curl_form_post(self.curl, p)
+  }//end formAddPost
+}

--- a/Tests/PerfectCURLTests/PerfectCURLTests.swift
+++ b/Tests/PerfectCURLTests/PerfectCURLTests.swift
@@ -207,6 +207,53 @@ class PerfectCURLTests: XCTestCase {
 //    XCTAssertEqual(r.0, 0)
 //  }
 
+  func testFORMPost () {
+    let fields = CURL.POSTFields()
+    let testStr = "varStringValue🇨🇳🇨🇦"
+    var r = fields.append(key: "varString", value: testStr)
+    guard r.rawValue == 0 else {
+      XCTFail("post form appending string field: \(r.rawValue)")
+      return
+    }
+    let buf: [Int8] = [1, 2, 3, 4, 5, 6, 7, 8]
+    r = fields.append(key: "varBuffer", buffer: buf)
+    guard r.rawValue == 0 else {
+      XCTFail("post form appending buffer field: \(r.rawValue)")
+      return
+    }
+    let testFile = "variable file content 🇨🇳 🇨🇦\n\0"
+    let path = "/tmp/postfile.txt"
+    let f = fopen(path, "wb")
+    fwrite(testFile, 1, testFile.utf8.count, f)
+    fclose(f)
+
+    r = fields.append(key: "varFile", path: path)
+    guard r.rawValue == 0 else {
+      XCTFail("post form appending file field: \(r.rawValue)")
+      return
+    }
+
+    let curl = CURL(url: "http://apa.perfect.org/hello.cgi")
+    let ret = curl.formAddPost(fields: fields)
+    guard ret.rawValue == 0 else {
+      let str = curl.strError(code: ret)
+      XCTFail("posting form: \(str)")
+      return
+    }//end guard
+
+    //let _ = curl.setOption(CURLOPT_VERBOSE, int: 1)
+
+    let exec = curl.performFullySync()
+    XCTAssertEqual(exec.0, 0)
+    XCTAssertEqual(exec.1, 200)
+    XCTAssertNotNil(strstr(String(cString:exec.2), "100 Continue"))
+    let content = String(cString:exec.3)
+    XCTAssertNotNil(strstr(content, testStr))
+    XCTAssertNotNil(strstr(content, testFile))
+    print(content)
+    curl.close()
+  }
+  
 	static var allTests : [(String, (PerfectCURLTests) -> () throws -> Void)] {
 		return [
 			("testCURLPost", testCURLPost),
@@ -214,6 +261,7 @@ class PerfectCURLTests: XCTestCase {
 			("testPerformFullySync", testPerformFullySync),
 			("testCURLAsync", testCURLAsync),
 //			("testSMTP", testSMTP),
+      ("testFORMPost", testFORMPost),
 			("testCURL", testCURL)
 		]
 	}


### PR DESCRIPTION
Patching the current Perfect-CURL with powerful curl_form() post functions. Fully compatible with Swift 3.1 both on Linux/macOS. To test it, simply setup a Apache 2.4 with a cgi file which can read out all stdin such as:
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

int main(int argc, char * argv[]) {
	printf("Content-type: text/html\n\n");
	printf("<HTML><H1>Hello, World</H1><pre>\n");
	for (int i = 0; i < argc; i++) {
		printf("%s\n", argv[i]);
	}//next i
	char buf[256];
	while(!feof(stdin)) {
		memset(buf, 0, 256);
		size_t r = fread(buf, 1, 256, stdin);
		if (r > 0) 
			fwrite(buf, 1, r, stdout);
		else
			break;
		//end if
	}//end while
	printf("</pre></HTML>\n");
	return 0;
}
```